### PR TITLE
feat: add executive AI briefing site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# exec-c
+# DevXP AI Executive Briefing
+
+This repository hosts a lightweight static site that summarizes the state of AI in developer tooling for a C-suite audience. The site provides talking points, industry trends, and strategic opportunities tailored for the DevXP initiative.
+
+## GitHub Pages
+
+1. In the repository settings, enable **GitHub Pages**.
+2. Select the `main` branch and the **root** directory.
+3. The site will be available at `https://<your-org>.github.io/exec-c/`.
+
+## Development
+
+The site is built with [Bootstrap 5](https://getbootstrap.com/) and custom styles matching company colors. Content is edited directly in `index.html`.
+
+Pull requests are welcome for updates to messaging or design.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>DevXP AI Strategy Briefing</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
+  <link href="style.css" rel="stylesheet">
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+    <div class="container-fluid">
+      <a class="navbar-brand" href="#">DevXP</a>
+    </div>
+  </nav>
+
+  <header class="py-5 text-center bg-light border-bottom">
+    <div class="container">
+      <h1 class="display-4 fw-bold">AI & Developer Tooling Executive Briefing</h1>
+      <p class="lead">Clear talking points and strategic direction for the modern enterprise.</p>
+    </div>
+  </header>
+
+  <main class="container my-5">
+    <section class="mb-5">
+      <h2 class="mb-3">1. AI & Developer Tooling Landscape</h2>
+      <ul class="list-group list-group-flush">
+        <li class="list-group-item">Generative coding assistants accelerate feature delivery and reduce boilerplate.</li>
+        <li class="list-group-item">Automated code review and testing services improve reliability and security.</li>
+        <li class="list-group-item">AI-powered knowledge bases capture tribal knowledge and streamline onboarding.</li>
+      </ul>
+    </section>
+
+    <section class="mb-5">
+      <h2 class="mb-3">2. Industry Momentum</h2>
+      <ul class="list-group list-group-flush">
+        <li class="list-group-item">Major cloud vendors integrate AI directly into DevOps pipelines.</li>
+        <li class="list-group-item">Open-source ecosystems rapidly release fine-tuned models for niche tooling.</li>
+        <li class="list-group-item">Regulatory focus on responsible AI drives auditability and data governance features.</li>
+      </ul>
+    </section>
+
+    <section class="mb-5">
+      <h2 class="mb-3">3. Strategic Opportunities for DevXP</h2>
+      <ul class="list-group list-group-flush">
+        <li class="list-group-item">Embed secure, policy-aware coding assistants into IDEs.</li>
+        <li class="list-group-item">Leverage AI analytics to prioritize technical debt and developer pain points.</li>
+        <li class="list-group-item">Provide self-service environments with intelligent templates and guardrails.</li>
+      </ul>
+    </section>
+
+    <section class="mb-5">
+      <h2 class="mb-3">4. Executive Talking Points</h2>
+      <ul class="list-group list-group-flush">
+        <li class="list-group-item">"AI augmented tooling elevates developer productivity and retention."</li>
+        <li class="list-group-item">"Responsible governance is a differentiator as AI adoption scales."</li>
+        <li class="list-group-item">"Investing now positions DevXP to lead our industry's digital transformation."</li>
+      </ul>
+    </section>
+
+    <section class="mb-5">
+      <h2 class="mb-3">5. Resources & Next Steps</h2>
+      <p>Explore pilots, gather developer feedback, and partner with security and compliance teams to ensure responsible use of AI.</p>
+      <a href="https://openai.com/" class="btn btn-secondary" target="_blank">Explore AI Platforms</a>
+    </section>
+  </main>
+
+  <footer class="text-center py-4 bg-primary text-white">
+    <small>DevXP &copy; 2024</small>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,22 @@
+:root {
+  --bs-primary: #00263a;
+  --bs-secondary: #fdb515;
+}
+
+body {
+  font-family: 'Inter', sans-serif;
+  color: #212529;
+}
+
+h1, h2 {
+  font-weight: 600;
+}
+
+.list-group-item {
+  padding-left: 0;
+  border: none;
+}
+
+footer {
+  background-color: var(--bs-primary);
+}


### PR DESCRIPTION
## Summary
- build a static "DevXP" site for executive talking points on AI and developer tooling
- style with company-inspired colors and Inter font
- document how to publish on GitHub Pages

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68967a1a41f0832f9f2f53f1c27608a2